### PR TITLE
Experiment with code restructure, to use Object.create, not new FunctionName()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,5 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - run: npm ci
-
-steps:
-    - name: Run tests
-      run: pytest
-
+      
       - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,33 +33,33 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [12.x, 14.x]
 
     steps:
       - uses: actions/checkout@v2
 
-      # - name: Cache node modules
-      #   uses: actions/cache@v2
-      #   env:
-      #     cache-name: cache-node-modules
-      #   with:
-      #     # npm cache files are stored in `~/.npm` on Linux/macOS
-      #     path: ~/.npm
-      #     key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-build-${{ env.cache-name }}-
-      #       ${{ runner.os }}-build-
-      #       ${{ runner.os }}-
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
 
-      # this is a debugging step to explore why this test fails
-      # in I when it works locally
-      - name: tmate session if tests fail
-        uses: mxschmitt/action-tmate@v3
-
-
       - run: npm ci
+
+steps:
+    - name: Run tests
+      run: pytest
+
+      - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,5 +57,8 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - run: npm ci
-
-      - run: npm test
+      # this is a debugging step to explore why this test fails
+      # in I when it works locally
+      - name: tmate session if tests fail
+        if: failure() && github.event_name == 'workflow_dispatch'
+        uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,26 +36,26 @@ jobs:
         node-version: [12.x, 14.x]
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Cache node modules
-      uses: actions/cache@v2
-      env:
-        cache-name: cache-node-modules
-      with:
-        # npm cache files are stored in `~/.npm` on Linux/macOS
-        path: ~/.npm
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
-          
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    
-    - run: npm ci
-    
-    - run: npm test
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - run: npm ci
+
+      - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,23 +33,23 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [12.x]
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Cache node modules
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-node-modules
-        with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+      # - name: Cache node modules
+      #   uses: actions/cache@v2
+      #   env:
+      #     cache-name: cache-node-modules
+      #   with:
+      #     # npm cache files are stored in `~/.npm` on Linux/macOS
+      #     path: ~/.npm
+      #     key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-build-${{ env.cache-name }}-
+      #       ${{ runner.os }}-build-
+      #       ${{ runner.os }}-
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
@@ -60,5 +60,4 @@ jobs:
       # this is a debugging step to explore why this test fails
       # in I when it works locally
       - name: tmate session if tests fail
-        if: failure() && github.event_name == 'workflow_dispatch'
         uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,10 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - run: npm ci
       # this is a debugging step to explore why this test fails
       # in I when it works locally
       - name: tmate session if tests fail
         uses: mxschmitt/action-tmate@v3
+
+
+      - run: npm ci

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-
 # Grid intensity polyfill
 
 _A polyfill, to build awareness of carbon intensity into javascript programs - move your code through time and space for greener digital products._
 
-The dream is for this to be built into the browser, so we learn as web makers to do the right thing by default, and incorporate carbon-aware practices into how we work. Partly inspired by the work by [Michelle Thorne and Yulia Startsev on Firefox Eco Mode concepts][1] and sustainablity engineering, and by [Lucia Ye's recent  work on Onlign OS][2], and [David Sykes work on the energy onion model][3], and [Auke Hoekste's work on energy systems as ecosystems][4]
+The dream is for this to be built into the browser, so we learn as web makers to do the right thing by default, and incorporate carbon-aware practices into how we work. Partly inspired by the work by [Michelle Thorne and Yulia Startsev on Firefox Eco Mode concepts][1] and sustainablity engineering, and by [Lucia Ye's recent work on Onlign OS][2], and [David Sykes work on the energy onion model][3], and [Auke Hoekste's work on energy systems as ecosystems][4]
 
 [1]: https://discourse.mozilla.org/t/firefox-eco-mode-brainstorming-how-can-the-internet-tackle-the-climate-emergency/46582/2
 [2]: https://2020.rca.ac.uk/students/lu-ye/
@@ -16,7 +15,7 @@ The dream is for this to be built into the browser, so we learn as web makers to
 import GridIntensity from '@tgwf/grid-intensity-polyfill'
 
 // initialise
-grid = GridIntensity()
+const grid = Object.create( GridIntensity )
 
 const carbonIndex = await grid.getCarbonIndex()
 
@@ -57,16 +56,15 @@ cp ./lib/gridintensity.browser.js ./lib/gridintensity.browser.min.js ./public
 npx run serve public
 ```
 
-
 ### Background
 
 We know that the internet runs on electricity. That electricity comes from a mix of energy sources, including wind and solar, nuclear power, biomass, fossil gas, oil and coal and so on,
 
-We call this the *fuel mix*, and this fuel mix can impact on the *carbon intensity* of your code.
+We call this the _fuel mix_, and this fuel mix can impact on the _carbon intensity_ of your code.
 
 ### Move your code through time and space
 
-Because the fuel mix will be different depending when and where you run your code, you can influence the carbon intensity of the code you write by moving it through time and space - either by making it run *when* the grid is greener, or making it run *where* it's greener, like a CDN running on green power.
+Because the fuel mix will be different depending when and where you run your code, you can influence the carbon intensity of the code you write by moving it through time and space - either by making it run _when_ the grid is greener, or making it run _where_ it's greener, like a CDN running on green power.
 
 This API is designed to make that easier. It pulls data from open data sources, about the predicted carbon intensity of energy on the grid where code is run, and presents an object you can query, so you can make an application or website serve a different experience to end users based on the carbon intensity.
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,5 @@
 // babel.config.js
 module.exports = {
-
   presets: [
     [
       "@babel/preset-env",

--- a/jest.config.js
+++ b/jest.config.js
@@ -144,10 +144,7 @@ module.exports = {
   // ],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-  testPathIgnorePatterns: [
-    "/node_modules/",
-    "/lib/*"
-  ],
+  testPathIgnorePatterns: ["/node_modules/", "/lib/*"],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files
   // testRegex: [],
@@ -168,10 +165,7 @@ module.exports = {
   // transform: null,
 
   // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
-  transformIgnorePatterns: [
-    "/node_modules/",
-    "/lib/"
-  ],
+  transformIgnorePatterns: ["/node_modules/", "/lib/"]
 
   // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
   // unmockedModulePathPatterns: undefined,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3271,12 +3271,11 @@
       "dev": true
     },
     "debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "dev": true,
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
       "requires": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
       }
     },
     "decamelize": {
@@ -6797,8 +6796,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "mute-stream": {
       "version": "0.0.8",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "cross-fetch": "^3.0.6",
+    "debug": "^4.3.1",
     "network-information-api-polyfill": "0.0.2",
     "node-localstorage": "^2.1.6"
   },

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -2,5 +2,5 @@ module.exports = {
   trailingComma: "none",
   tabWidth: 2,
   semi: false,
-  singleQuote: true
+  singleQuote: false
 }

--- a/public/index.html
+++ b/public/index.html
@@ -1,41 +1,32 @@
 <html>
-  <head>
-    <meta charset="utf-8" />
 
-    <style>
-      .low-grid-intensity {
-        background-color: #1cdcb4;
-        transition-duration: 1s;
-      }
+<head>
+	<meta charset="utf-8" />
 
-      .moderate-grid-intensity {
-        background-color: #51aee2;
-        transition-duration: 1s;
-      }
+	<style>
+		.low-grid-intensity {
+			background-color: #1cdcb4;
+			transition-duration: 1s;
+		}
 
-      .high-grid-intensity {
-        background-color: #ff7900;
-        transition-duration: 1s;
-      }
-    </style>
-  </head>
+		.moderate-grid-intensity {
+			background-color: #51aee2;
+			transition-duration: 1s;
+		}
 
-  <body class="">
-    <h1>The grid intensity in your part of the world right now is:</h1>
-    <h2 class="result">(result goes here)</h2>
+		.high-grid-intensity {
+			background-color: #ff7900;
+			transition-duration: 1s;
+		}
 
-    <script src="./gridintensity.browser.min.js"></script>
-    <script>
-      async function main() {
-        const grid = Object.create(GridIntensity)
-        await grid.setup()
-        const index = await grid.getCarbonIndex()
-        console.log({ index })
-        document.querySelector(".result").textContent = index
-        document.querySelector("body").classList = []
-        document.querySelector("body").classList.add(`${index}-grid-intensity`)
-      }
-      main()
-    </script>
-  </body>
+	</style>
+</head>
+
+<body class="">
+	<h1>The grid intensity in your part of the world right now is:</h1>
+	<h2 class="result">(result goes here)</h2>
+
+	<script src="./example.js"></script>
+</body>
+
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,55 +1,41 @@
 <html>
+  <head>
+    <meta charset="utf-8" />
 
-<head>
-  <meta charset=utf-8>
+    <style>
+      .low-grid-intensity {
+        background-color: #1cdcb4;
+        transition-duration: 1s;
+      }
 
+      .moderate-grid-intensity {
+        background-color: #51aee2;
+        transition-duration: 1s;
+      }
 
-  <style>
-    .low-grid-intensity {
-      background-color: #1CDCB4;
-      transition-duration: 1s;
-    }
+      .high-grid-intensity {
+        background-color: #ff7900;
+        transition-duration: 1s;
+      }
+    </style>
+  </head>
 
-    .moderate-grid-intensity {
-      background-color: #51AEE2;
-      transition-duration: 1s;
-    }
+  <body class="">
+    <h1>The grid intensity in your part of the world right now is:</h1>
+    <h2 class="result">(result goes here)</h2>
 
-    .high-grid-intensity {
-      background-color: #FF7900;
-      transition-duration: 1s;
-    }
-  </style>
-</head>
-
-
-
-<body class="">
-
-  <h1>
-    The grid intensity in your part of the world right now is:
-  </h1>
-  <h2 class="result">
-    (result goes here)
-  </h2>
-
-
-  <script src="./gridintensity.browser.min.js"></script>
-  <script>
-    async function main() {
-      const grid = new GridIntensity()
-      await grid.setup()
-      const index = await grid.getCarbonIndex()
-      console.log({ index })
-      document.querySelector('.result').textContent = index
-      document.querySelector('body').classList = []
-      document.querySelector('body').classList.add(`${index}-grid-intensity`)
-
-
-    }
-    main()
-
-  </script>
-</body>
-
+    <script src="./gridintensity.browser.min.js"></script>
+    <script>
+      async function main() {
+        const grid = Object.create(GridIntensity)
+        await grid.setup()
+        const index = await grid.getCarbonIndex()
+        console.log({ index })
+        document.querySelector(".result").textContent = index
+        document.querySelector("body").classList = []
+        document.querySelector("body").classList.add(`${index}-grid-intensity`)
+      }
+      main()
+    </script>
+  </body>
 </html>

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,42 +1,33 @@
 // rollup.config.js
-import resolve from '@rollup/plugin-node-resolve';
-import commonjs from '@rollup/plugin-commonjs';
-import { getBabelOutputPlugin } from '@rollup/plugin-babel';
-import babel from '@rollup/plugin-babel';
-import { terser } from 'rollup-plugin-terser';
-
+import resolve from "@rollup/plugin-node-resolve"
+import commonjs from "@rollup/plugin-commonjs"
+import { getBabelOutputPlugin } from "@rollup/plugin-babel"
+import babel from "@rollup/plugin-babel"
+import { terser } from "rollup-plugin-terser"
 
 const browserBuild = {
-  input: 'src/browser.js',
+  input: "src/browser.js",
   output: {
-    file: 'lib/gridintensity.browser.js',
-    format: 'iife',
+    file: "lib/gridintensity.browser.js",
+    format: "iife",
     name: "GridItensity"
   },
-  plugins: [
-    resolve(),
-  ]
+  plugins: [resolve()]
 }
 
 const browserBuildMin = {
-  input: 'src/browser.bundle.js',
+  input: "src/browser.bundle.js",
   output: {
-    file: 'lib/gridintensity.browser.min.js'
+    file: "lib/gridintensity.browser.min.js"
   },
-  plugins: [
-    resolve(),
-    babel({ babelHelpers: 'bundled' }),
-    terser()
-  ]
+  plugins: [resolve(), babel({ babelHelpers: "bundled" }), terser()]
 }
 
-
-
 const nodeBuild = {
-  input: 'src/node.js',
+  input: "src/node.js",
   output: {
-    file: 'lib/index.js',
-    format: 'cjs',
+    file: "lib/index.js",
+    format: "cjs",
     exports: "default"
   },
   plugins: [
@@ -44,20 +35,20 @@ const nodeBuild = {
       preferBuiltins: true
     }),
     commonjs(),
-    babel({ babelHelpers: 'bundled' }),
+    babel({ babelHelpers: "bundled" }),
     getBabelOutputPlugin({
-      presets: [['@babel/preset-env',
-        {
-          targets: {
-            node: "current"
+      presets: [
+        [
+          "@babel/preset-env",
+          {
+            targets: {
+              node: "current"
+            }
           }
-        }]]
+        ]
+      ]
     })
   ]
 }
 
-export default [
-  browserBuild,
-  browserBuildMin,
-  nodeBuild
-];
+export default [browserBuild, browserBuildMin, nodeBuild]

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,6 +23,16 @@ const browserBuildMin = {
   plugins: [resolve(), babel({ babelHelpers: "bundled" }), terser()]
 }
 
+const browserExample = {
+  input: "src/example.js",
+  output: {
+    file: "public/example.js",
+    format: "iife",
+    name: "GridItensity"
+  },
+  plugins: [resolve()]
+}
+
 const nodeBuild = {
   input: "src/node.js",
   output: {
@@ -51,4 +61,4 @@ const nodeBuild = {
   ]
 }
 
-export default [browserBuild, browserBuildMin, nodeBuild]
+export default [browserBuild, browserBuildMin, nodeBuild, browserExample]

--- a/src/browser.bundle.js
+++ b/src/browser.bundle.js
@@ -1,4 +1,4 @@
 // this exists to provide an easy to include script tag for browsers
 
-import GridIntensity from './browser'
+import GridIntensity from "./browser"
 window.GridIntensity = GridIntensity

--- a/src/browser.js
+++ b/src/browser.js
@@ -1,28 +1,16 @@
-import GridIntensityMixin from "./gridIntensity"
+// 3rd party / native libs
 
+// local to this project
+import GridIntensityMixin from "./gridIntensity"
+import settings from "./defaultSettings"
+
+// set up our objects
 const GridIntensity = Object.create(GridIntensityMixin)
 
 GridIntensity.fetch = fetch
 GridIntensity.localStorage = localStorage
 GridIntensity.data = []
 GridIntensity.intensityProvider = settings.uk
-
-GridIntensity.fetchIntensityData = async function () {
-  const now = new Date()
-  const [before, after] = this.intensityProvider.api.forwardLooking.split(
-    "{from}"
-  )
-  const urlString = `${before}${now.toISOString()}${after}/`
-  let res = await fetch(urlString)
-  this.data = await res.json()
-  return this.data
-}
-
-GridIntensity.getCarbonIndex = async function (options) {
-  let now = this.getInterval(options)
-  const latestReading = await this.getReadingForInterval(now)
-  return latestReading.intensity.index
-}
 
 export default GridIntensity
 

--- a/src/browser.js
+++ b/src/browser.js
@@ -1,14 +1,17 @@
-import GridIntensity from './gridintensity'
+import GridIntensityMixin from "./gridintensity"
 
-GridIntensity.prototype.fetch = fetch
-GridIntensity.prototype.localStorage = localStorage
+const GridIntensity = Object.create(GridIntensityMixin)
 
-// we need to override the function here because we otherwise get the error in browsers
-// TypeError: 'fetch' called on an object that does not implement interface Window
-GridIntensity.prototype.fetchIntensityData = async function () {
+GridIntensity.fetch = fetch
+GridIntensity.localStorage = localStorage
+GridIntensity.data = []
+GridIntensity.intensityProvider = settings.uk
 
+GridIntensity.fetchIntensityData = async function () {
   const now = new Date()
-  const [before, after] = this.intensityProvider.api.forwardLooking.split("{from}")
+  const [before, after] = this.intensityProvider.api.forwardLooking.split(
+    "{from}"
+  )
   const urlString = `${before}${now.toISOString()}${after}/`
   let res = await fetch(urlString)
   this.data = await res.json()

--- a/src/browser.js
+++ b/src/browser.js
@@ -18,4 +18,11 @@ GridIntensity.fetchIntensityData = async function () {
   return this.data
 }
 
+GridIntensity.getCarbonIndex = async function (options) {
+  let now = this.getInterval(options)
+  const latestReading = await this.getReadingForInterval(now)
+  return latestReading.intensity.index
+}
+
 export default GridIntensity
+

--- a/src/browser.js
+++ b/src/browser.js
@@ -1,4 +1,4 @@
-import GridIntensityMixin from "./gridintensity"
+import GridIntensityMixin from "./gridIntensity"
 
 const GridIntensity = Object.create(GridIntensityMixin)
 

--- a/src/browser.js
+++ b/src/browser.js
@@ -1,4 +1,5 @@
 // 3rd party / native libs
+import debugLib from 'debug'
 
 // local to this project
 import GridIntensityMixin from "./gridIntensity"
@@ -6,11 +7,23 @@ import settings from "./defaultSettings"
 
 // set up our objects
 const GridIntensity = Object.create(GridIntensityMixin)
+// const debug = debugLib('tgwf.Gridintensity.node')
 
-GridIntensity.fetch = fetch
-GridIntensity.localStorage = localStorage
+GridIntensity.localStorage = window.localStorage
 GridIntensity.data = []
 GridIntensity.intensityProvider = settings.uk
+
+GridIntensity.fetchIntensityData = async function () {
+  const urlString = this.buildFetchUrl()
+  try {
+    const res = await fetch(urlString)
+    this.data = await res.json()
+  } catch (error) {
+    console.error("Couldn't fetch new data. Doing nothing further")
+    console.error(error)
+  }
+  return this.data
+}
 
 export default GridIntensity
 

--- a/src/defaultSettings.js
+++ b/src/defaultSettings.js
@@ -2,7 +2,8 @@ export default {
   uk: {
     api: {
       current: "https://api.carbonintensity.org.uk/intensity",
-      forwardLooking: "https://api.carbonintensity.org.uk/intensity/{from}/fw24h",
+      forwardLooking:
+        "https://api.carbonintensity.org.uk/intensity/{from}/fw24h"
     },
     provider: "National Grid"
   }

--- a/src/example.js
+++ b/src/example.js
@@ -1,0 +1,13 @@
+import GridIntensity from "./browser"
+
+async function main() {
+  const grid = Object.create(GridIntensity)
+  await grid.setup(window.fetch)
+  const index = await grid.getCarbonIndex()
+
+  document.querySelector(".result").textContent = index
+  document.querySelector("body").classList = []
+  document.querySelector("body").classList.add(`${index}-grid-intensity`)
+}
+
+main()

--- a/src/gridIntensity.js
+++ b/src/gridIntensity.js
@@ -1,11 +1,26 @@
+import debugLib from 'debug'
+const debug = debugLib('tgwf.GridIntensity')
+
+class NoMoreIntervalsError extends Error { }
+
 const GridIntensityMixin = {
+  /**
+   * Populate the local cache with carbon intensity
+   * data, ready for queries.
+   */
   async setup() {
     this.data = this.getLocalIntensityData()
 
     if (this.data.length < 1) {
+      debug("setup")
       this.data = await this.fetchIntensityData()
     }
   },
+  /**
+   * Fetch cached carbon intensity data, returning
+   * an array of carbon intensity objects, or an empty
+   * array if nothing present
+   */
   getLocalIntensityData() {
     let storage = this.localStorage
     const intervalsString = storage.getItem("gridIntensityData")
@@ -29,26 +44,39 @@ const GridIntensityMixin = {
       return []
     }
   },
+  /**
+   * Return next 30 minute interval from the list of 30 minute
+   * intervals containing carbon intensity data, based on the
+   * date in the object passed in. Returns the next date based
+   * on the current time if no data provided
+   */
   getNextInterval(options) {
-    // returns very next 30 minute interval from the list of intervals
-    // loops forward through the intervals, checking it the time now is
-    // greater, and returns the first one to be greater than now, AND less than
-    // 31mins ahead too
+
+    debug("getNextInterval")
 
     let now
+    let nextInterval = null
     if (options && options.checkDate) {
       now = options.checkDate
     } else {
       now = new Date()
     }
+    // loop forward through the intervals, and checkin if the time now is
+    // greater, and return the first one to be greater than now, AND less than
+    // 31mins ahead too
     for (const inter of this.data.data) {
+      debug({ inter })
+      debug({ to: inter.to })
       const until = Date.parse(inter.to)
 
       if (until > now) {
-        return inter
+        nextInterval = inter
       }
     }
-    return null
+    if (!nextInterval) {
+      throw new NoMoreIntervalsError("We didn't find any more intervals left to interate through");
+    }
+    return nextInterval
   },
   getInterval(options) {
     let now
@@ -61,46 +89,80 @@ const GridIntensityMixin = {
   },
 
   async getReadingForInterval(requiredDate) {
-    let latestReading
-    latestReading = this.getNextInterval({ checkDate: requiredDate })
+    debug("getReadingForInterval")
+    try {
+      let latestReading = this.getNextInterval({ checkDate: requiredDate })
+      debug({ latestReading })
+      // return latestReading.intensity.index
+    } catch (err) {
+      if (err instanceof NoMoreIntervalsError) {
+        debug(`No intervals found locally later than ${requiredDate}`)
+      } else {
+        debug(e)
+      }
+      return null
+    }
+
     if (!latestReading) {
       // fetch new data, and try again
-      const newIntervals = await this.fetchIntensityData()
-      let storage = this.localStorage
-      storage.setItem("gridIntensityData", JSON.stringify(newIntervals))
-      this.data = newIntervals
+      debug("Trying the API to fetch for new grid intensity data")
+      let newIntervals
+      try {
+        newIntervals = await this.fetchIntensityData()
+        let storage = this.localStorage
+        storage.setItem("gridIntensityData", JSON.stringify(newIntervals))
+        this.data = newIntervals
+      } catch (err) {
+        debug("err", e)
+      }
+
+      debug({ requiredDate })
       latestReading = this.getNextInterval({ checkDate: requiredDate })
     }
+    debug({ latestReading })
 
     const latestReadingDate = Date.parse(latestReading.to)
 
     if (requiredDate > latestReadingDate) {
       // fetch new data, as this out of date
-      this.data = await this.fetchIntensityData()
-      latestReading = this.data.data[0]
+      try {
+        this.data = await this.fetchIntensityData()
+        latestReading = this.data.data[0]
+      } catch (err) {
+        console.error("problem fetching latest reading")
+        console.error(err)
+      }
+
+
     }
     return latestReading
   },
-  async fetchIntensityData() {
+  /**
+   * Build and return the url for sending a fetch() request to the chosen provider
+   */
+  buildFetchUrl() {
     const now = new Date()
-  const [before, after] = this.intensityProvider.api.forwardLooking.split(
-    "{from}"
-  )
-  const urlString = `${before}${now.toISOString()}${after}/`
-  let res
-  try {
-    res = await this.fetch(urlString)
-    this.data = await res.json()
-  } catch (error) {
-      console.error("Couldn't fetch new data. Doing nothing further")
-      console.error(error)
-  }
-  return this.data
+    const [before, after] = this.intensityProvider.api.forwardLooking.split(
+      "{from}"
+    )
+    return `${before}${now.toISOString()}${after}/`
   },
+  /**
+   * Fetch the carbon index for the time interval in the options
+   * provided
+   * Returns a string, describing the carbon intensity
+   */
   async getCarbonIndex(options) {
     let now = this.getInterval(options)
-    const latestReading = await this.getReadingForInterval(now)
-    return latestReading.intensity.index
+    try {
+      const latestReading = await this.getReadingForInterval(now)
+      debug({ latestReading })
+      return latestReading
+    } catch (err) {
+      debug("Problem fetching the reading for interval", now)
+      console.error(err)
+
+    }
   }
 
 }

--- a/src/gridIntensity.js
+++ b/src/gridIntensity.js
@@ -50,34 +50,36 @@ const GridIntensityMixin = {
     }
     return null
   },
-  async getCarbonIndex(options) {
+  getInterval(options) {
     let now
     if (options && options.checkDate) {
       now = options.checkDate
     } else {
       now = new Date()
     }
+    return now
+  },
 
+  async getReadingForInterval(requiredDate) {
     let latestReading
-    latestReading = this.getNextInterval({ checkDate: now })
+    latestReading = this.getNextInterval({ checkDate: requiredDate })
     if (!latestReading) {
       // fetch new data, and try again
       const newIntervals = await this.fetchIntensityData()
       let storage = this.localStorage
       storage.setItem("gridIntensityData", JSON.stringify(newIntervals))
       this.data = newIntervals
-      latestReading = this.getNextInterval({ checkDate: now })
+      latestReading = this.getNextInterval({ checkDate: requiredDate })
     }
 
     const latestReadingDate = Date.parse(latestReading.to)
 
-    if (now > latestReadingDate) {
+    if (requiredDate > latestReadingDate) {
       // fetch new data, as this out of date
       this.data = await this.fetchIntensityData()
       latestReading = this.data.data[0]
     }
-
-    return latestReading.intensity.index
+    return latestReading
   }
 }
 

--- a/src/gridIntensity.js
+++ b/src/gridIntensity.js
@@ -1,5 +1,5 @@
 const GridIntensityMixin = {
-  async setup(localStorage, fetch) {
+  async setup() {
     this.data = this.getLocalIntensityData()
 
     if (this.data.length < 1) {

--- a/src/gridIntensity.js
+++ b/src/gridIntensity.js
@@ -1,110 +1,84 @@
-import settings from './defaultSettings'
-const intensityProvider = settings.uk
+const GridIntensityMixin = {
+  async setup(localStorage, fetch) {
+    this.data = this.getLocalIntensityData()
 
-function GridIntensity() {
-  this.data = []
-  this.intensityProvider = intensityProvider
-}
-
-
-GridIntensity.prototype.setup = async function (localStorage, fetch) {
-
-  this.data = this.getLocalIntensityData()
-
-  if (this.data.length < 1) {
-    this.data = await this.fetchIntensityData()
-  }
-}
-GridIntensity.prototype.getLocalIntensityData = function () {
-
-  let storage = this.localStorage
-  const intervalsString = (storage.getItem('gridIntensityData'))
-
-  if (!intervalsString) {
-    return []
-  }
-
-  // we have no local data - return early
-  if (!intervalsString.length) {
-    return []
-  }
-
-
-  // try to parse what we already have
-  try {
-    parsedIntervals = JSON.parse(intervalsString)
-    console.debug({ parsedIntervals })
-    return parsedIntervals
-  } catch (err) {
-    storage.setItem('gridIntensityData', [])
-    return []
-  }
-}
-GridIntensity.prototype.getNextInterval = function (options) {
-  // returns very next 30 minute interval from the list of intervals
-  // loops forward through the intervals, checking it the time now is
-  // greater, and returns the first one to be greater than now, AND less than
-  // 31mins ahead too
-
-
-  let now
-  if (options && options.checkDate) {
-    now = options.checkDate
-  } else {
-    now = new Date()
-  }
-  for (const inter of this.data.data) {
-
-    const until = Date.parse(inter.to)
-
-    if (until > now) {
-      return inter
+    if (this.data.length < 1) {
+      this.data = await this.fetchIntensityData()
     }
-  }
-  return null
-
-}
-
-
-GridIntensity.prototype.getCarbonIndex = async function (options) {
-  let now
-  if (options && options.checkDate) {
-    now = options.checkDate
-  } else {
-    now = new Date()
-  }
-
-  let latestReading
-  latestReading = this.getNextInterval({ checkDate: now })
-  if (!latestReading) {
-    // fetch new data, and try again
-    const newIntervals = await this.fetchIntensityData()
+  },
+  getLocalIntensityData() {
     let storage = this.localStorage
-    storage.setItem('gridIntensityData', JSON.stringify(newIntervals))
-    this.data = newIntervals
+    const intervalsString = storage.getItem("gridIntensityData")
+
+    if (!intervalsString) {
+      return []
+    }
+
+    // we have no local data - return early
+    if (!intervalsString.length) {
+      return []
+    }
+
+    // try to parse what we already have
+    try {
+      parsedIntervals = JSON.parse(intervalsString)
+      console.debug({ parsedIntervals })
+      return parsedIntervals
+    } catch (err) {
+      storage.setItem("gridIntensityData", [])
+      return []
+    }
+  },
+  getNextInterval(options) {
+    // returns very next 30 minute interval from the list of intervals
+    // loops forward through the intervals, checking it the time now is
+    // greater, and returns the first one to be greater than now, AND less than
+    // 31mins ahead too
+
+    let now
+    if (options && options.checkDate) {
+      now = options.checkDate
+    } else {
+      now = new Date()
+    }
+    for (const inter of this.data.data) {
+      const until = Date.parse(inter.to)
+
+      if (until > now) {
+        return inter
+      }
+    }
+    return null
+  },
+  async getCarbonIndex(options) {
+    let now
+    if (options && options.checkDate) {
+      now = options.checkDate
+    } else {
+      now = new Date()
+    }
+
+    let latestReading
     latestReading = this.getNextInterval({ checkDate: now })
+    if (!latestReading) {
+      // fetch new data, and try again
+      const newIntervals = await this.fetchIntensityData()
+      let storage = this.localStorage
+      storage.setItem("gridIntensityData", JSON.stringify(newIntervals))
+      this.data = newIntervals
+      latestReading = this.getNextInterval({ checkDate: now })
+    }
+
+    const latestReadingDate = Date.parse(latestReading.to)
+
+    if (now > latestReadingDate) {
+      // fetch new data, as this out of date
+      this.data = await this.fetchIntensityData()
+      latestReading = this.data.data[0]
+    }
+
+    return latestReading.intensity.index
   }
-
-  const latestReadingDate = Date.parse(latestReading.to)
-
-  if (now > latestReadingDate) {
-    // fetch new data, as this out of date
-    this.data = await this.fetchIntensityData()
-    latestReading = this.data.data[0]
-  }
-
-  return latestReading.intensity.index
-
 }
 
-GridIntensity.prototype.fetchIntensityData = async function () {
-
-  const now = new Date()
-  const [before, after] = this.intensityProvider.api.forwardLooking.split("{from}")
-  const urlString = `${before}${now.toISOString()}${after}/`
-  let res = await this.fetch(urlString)
-  this.data = await res.json()
-  return this.data
-}
-
-export default GridIntensity
+export default GridIntensityMixin

--- a/src/gridIntensity.js
+++ b/src/gridIntensity.js
@@ -80,7 +80,29 @@ const GridIntensityMixin = {
       latestReading = this.data.data[0]
     }
     return latestReading
+  },
+  async fetchIntensityData() {
+    const now = new Date()
+  const [before, after] = this.intensityProvider.api.forwardLooking.split(
+    "{from}"
+  )
+  const urlString = `${before}${now.toISOString()}${after}/`
+  let res
+  try {
+    res = await this.fetch(urlString)
+    this.data = await res.json()
+  } catch (error) {
+      console.error("Couldn't fetch new data. Doing nothing further")
+      console.error(error)
   }
+  return this.data
+  },
+  async getCarbonIndex(options) {
+    let now = this.getInterval(options)
+    const latestReading = await this.getReadingForInterval(now)
+    return latestReading.intensity.index
+  }
+
 }
 
 export default GridIntensityMixin

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import GridIntensity from './node'
+import GridIntensity from "./node"
 
 // TODO if there is a wy to tell which environmen we're in
 // we should load in the corresponding version.

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,20 +1,18 @@
 import GridIntensity from "./node"
 
-
-
 // not sure how to mock this, so using an array here as it's the slowest part of the test
 describe("GridIntensity", () => {
   let fakeData
   beforeEach(() => {
-    fakeData = '{"data":[{"from":"2020-09-19T11:30Z","to":"2020-09-19T12:00Z","intensity":{"forecast":83,"actual":85,"index":"low"}}]}'
+    fakeData =
+      '{"data":[{"from":"2020-09-19T11:30Z","to":"2020-09-19T12:00Z","intensity":{"forecast":83,"actual":85,"index":"low"}}]}'
   })
 
   describe("fetching intensity data", () => {
-
     test("fetches data on instantion, if nothing is available locally", async () => {
-      const grid = new GridIntensity()
+      const grid = Object.create(GridIntensity)
 
-      grid.fetchIntensityData = jest.fn(x => {
+      grid.fetchIntensityData = jest.fn((x) => {
         return fakeData
       })
       await grid.setup()
@@ -23,9 +21,9 @@ describe("GridIntensity", () => {
       expect(grid.fetchIntensityData).toHaveBeenCalled()
     })
     test("fetches data on instantion, recovers gracefully when no data from API", async () => {
-      const grid = new GridIntensity()
+      const grid = Object.create(GridIntensity)
 
-      grid.fetchIntensityData = jest.fn(x => {
+      grid.fetchIntensityData = jest.fn((x) => {
         return Promise.resolve([])
       })
       await grid.setup()
@@ -35,9 +33,9 @@ describe("GridIntensity", () => {
     })
 
     test("uses a local store when created if available", async () => {
-      const grid = new GridIntensity()
+      const grid = Object.create(GridIntensity)
       grid.data = fakeData
-      grid.getLocalIntensityData = jest.fn(x => {
+      grid.getLocalIntensityData = jest.fn((x) => {
         return fakeData
       })
       grid.fetchIntensityData = jest.fn()
@@ -50,9 +48,9 @@ describe("GridIntensity", () => {
     })
 
     test("uses data from local store when present", async () => {
-      const grid = new GridIntensity()
+      const grid = Object.create(GridIntensity)
       grid.data = fakeData
-      grid.getLocalIntensityData = jest.fn(x => {
+      grid.getLocalIntensityData = jest.fn((x) => {
         return fakeData
       })
       grid.fetchIntensityData = jest.fn()
@@ -60,15 +58,12 @@ describe("GridIntensity", () => {
       grid.setup()
 
       //
-
     })
 
-
-
     test("recovers gracefully when no data from localstorage", async () => {
-      const grid = new GridIntensity()
+      const grid = Object.create(GridIntensity)
 
-      grid.getLocalIntensityData = jest.fn(x => {
+      grid.getLocalIntensityData = jest.fn((x) => {
         return Promise.resolve([])
       })
       await grid.setup()
@@ -77,13 +72,11 @@ describe("GridIntensity", () => {
       expect(grid.getLocalIntensityData).toHaveBeenCalled()
     })
 
-
-
     test("makes new request for data if local store is out of date", () => {
       // arrange
-      const grid = new GridIntensity()
+      const grid = Object.create(GridIntensity)
       grid.data = JSON.parse(fakeData)
-      grid.fetchIntensityData = jest.fn(x => {
+      grid.fetchIntensityData = jest.fn((x) => {
         return Promise.resolve(JSON.parse(fakeData))
       })
 
@@ -93,61 +86,62 @@ describe("GridIntensity", () => {
       // assert
       expect(grid.fetchIntensityData).toHaveBeenCalled()
     })
-
   })
   describe("exposing intensity data API", () => {
     let grid, data
     beforeEach(() => {
-      grid = new GridIntensity()
+      grid = Object.create(GridIntensity)
       data = JSON.parse(fakeData)
-      grid.fetchIntensityData = jest.fn(x => {
+      grid.fetchIntensityData = jest.fn((x) => {
         return Promise.resolve(data)
       })
     })
 
     test("returns high carbonindex value", async () => {
       // arrange
-      data.data[0].intensity.index = 'high'
+      data.data[0].intensity.index = "high"
       grid.data = data
       // act
-      const result = await grid.getCarbonIndex({ checkDate: Date.parse("2020-09-19T11:40Z") })
-
+      const result = await grid.getCarbonIndex({
+        checkDate: Date.parse("2020-09-19T11:40Z")
+      })
 
       // assert
-      expect(result).toBe('high')
+      expect(result).toBe("high")
       expect(grid.fetchIntensityData).toHaveBeenCalledTimes(0)
     })
     test("returns medium carbonindex value", async () => {
       // arrange
-      data.data[0].intensity.index = 'med'
+      data.data[0].intensity.index = "med"
       grid.data = data
       // act
 
-      const result = await grid.getCarbonIndex({ checkDate: Date.parse("2020-09-19T11:40Z") })
-
+      const result = await grid.getCarbonIndex({
+        checkDate: Date.parse("2020-09-19T11:40Z")
+      })
 
       // assert
-      expect(result).toBe('med')
+      expect(result).toBe("med")
       expect(grid.fetchIntensityData).toHaveBeenCalledTimes(0)
     })
     test("returns low carbonindex value", async () => {
       // arrange
-      data.data[0].intensity.index = 'low'
+      data.data[0].intensity.index = "low"
       grid.data = data
       // act
-      const result = await grid.getCarbonIndex({ checkDate: Date.parse("2020-09-19T11:40Z") })
-
+      const result = await grid.getCarbonIndex({
+        checkDate: Date.parse("2020-09-19T11:40Z")
+      })
 
       // assert
-      expect(result).toBe('low')
+      expect(result).toBe("low")
       expect(grid.fetchIntensityData).toHaveBeenCalledTimes(0)
     })
   })
   describe("fetching next intensity interval", () => {
-
     let grid, data
     beforeEach(() => {
-      grid = new GridIntensity()
+      grid = Object.create(GridIntensity)
       data = JSON.parse(fakeData)
       // grid.fetchIntensityData = jest.fn()
     })
@@ -165,6 +159,5 @@ describe("GridIntensity", () => {
       // expect(minutesAhead).toBeGreaterThan(0)
       // is the interval ahead
     })
-
   })
 })

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -8,7 +8,7 @@ describe("GridIntensity", () => {
       '{"data":[{"from":"2020-09-19T11:30Z","to":"2020-09-19T12:00Z","intensity":{"forecast":83,"actual":85,"index":"low"}}]}'
   })
 
-  describe("fetching intensity data", () => {
+  describe.only("fetching intensity data", () => {
     test("fetches data on instantion, if nothing is available locally", async () => {
       const grid = Object.create(GridIntensity)
 
@@ -72,16 +72,18 @@ describe("GridIntensity", () => {
       expect(grid.getLocalIntensityData).toHaveBeenCalled()
     })
 
-    test("makes new request for data if local store is out of date", () => {
+    test.only("makes new request for data if local store is out of date", async () => {
       // arrange
       const grid = Object.create(GridIntensity)
       grid.data = JSON.parse(fakeData)
       grid.fetchIntensityData = jest.fn((x) => {
-        return Promise.resolve(JSON.parse(fakeData))
+        return Promise.resolve(JSON.parse(fakeData)).catch(function(e) {
+          console.log("OOOOO")
+        })
       })
 
       // act
-      grid.getCarbonIndex()
+      await grid.getCarbonIndex()
 
       // assert
       expect(grid.fetchIntensityData).toHaveBeenCalled()

--- a/src/node.js
+++ b/src/node.js
@@ -1,11 +1,27 @@
-import fetch from 'cross-fetch';
-import { LocalStorage } from 'node-localstorage'
+import fetch from "cross-fetch"
+import { LocalStorage } from "node-localstorage"
+import settings from "./defaultSettings"
 
-import GridIntensity from './gridIntensity'
+import GridIntensityMixin from "./gridIntensity"
 
-const localStorage = new LocalStorage('./scratch');
+const localStorage = new LocalStorage("./scratch")
 
-GridIntensity.prototype.fetch = fetch
-GridIntensity.prototype.localStorage = localStorage
+const GridIntensity = Object.create(GridIntensityMixin)
+
+GridIntensity.fetch = fetch
+GridIntensity.localStorage = localStorage
+GridIntensity.data = []
+GridIntensity.intensityProvider = settings.uk
+
+GridIntensity.fetchIntensityData = async function fetchIntensityData() {
+  const now = new Date()
+  const [before, after] = this.intensityProvider.api.forwardLooking.split(
+    "{from}"
+  )
+  const urlString = `${before}${now.toISOString()}${after}/`
+  let res = await this.fetch(urlString)
+  this.data = await res.json()
+  return this.data
+}
 
 export default GridIntensity

--- a/src/node.js
+++ b/src/node.js
@@ -24,4 +24,10 @@ GridIntensity.fetchIntensityData = async function fetchIntensityData() {
   return this.data
 }
 
+GridIntensity.getCarbonIndex = async function (options) {
+  let now = this.getInterval(options)
+  const latestReading = await this.getReadingForInterval(now)
+  return latestReading.intensity.index
+}
+
 export default GridIntensity

--- a/src/node.js
+++ b/src/node.js
@@ -13,7 +13,7 @@ GridIntensity.localStorage = localStorage
 GridIntensity.data = []
 GridIntensity.intensityProvider = settings.uk
 
-GridIntensity.fetchIntensityData = async function fetchIntensityData() {
+GridIntensity.fetchIntensityData = async function () {
   const now = new Date()
   const [before, after] = this.intensityProvider.api.forwardLooking.split(
     "{from}"

--- a/src/node.js
+++ b/src/node.js
@@ -1,33 +1,18 @@
+// 3rd party / native libs
 import fetch from "cross-fetch"
 import { LocalStorage } from "node-localstorage"
-import settings from "./defaultSettings"
 
+// local to this project
+import settings from "./defaultSettings"
 import GridIntensityMixin from "./gridIntensity"
 
+// set up our objects
 const localStorage = new LocalStorage("./scratch")
-
 const GridIntensity = Object.create(GridIntensityMixin)
 
 GridIntensity.fetch = fetch
 GridIntensity.localStorage = localStorage
 GridIntensity.data = []
 GridIntensity.intensityProvider = settings.uk
-
-GridIntensity.fetchIntensityData = async function () {
-  const now = new Date()
-  const [before, after] = this.intensityProvider.api.forwardLooking.split(
-    "{from}"
-  )
-  const urlString = `${before}${now.toISOString()}${after}/`
-  let res = await this.fetch(urlString)
-  this.data = await res.json()
-  return this.data
-}
-
-GridIntensity.getCarbonIndex = async function (options) {
-  let now = this.getInterval(options)
-  const latestReading = await this.getReadingForInterval(now)
-  return latestReading.intensity.index
-}
 
 export default GridIntensity

--- a/src/node.js
+++ b/src/node.js
@@ -1,18 +1,31 @@
 // 3rd party / native libs
 import fetch from "cross-fetch"
+import debugLib from 'debug'
 import { LocalStorage } from "node-localstorage"
 
 // local to this project
 import settings from "./defaultSettings"
 import GridIntensityMixin from "./gridIntensity"
-
+const debug = debugLib('tgwf.Gridintensity.node')
 // set up our objects
 const localStorage = new LocalStorage("./scratch")
 const GridIntensity = Object.create(GridIntensityMixin)
 
-GridIntensity.fetch = fetch
 GridIntensity.localStorage = localStorage
 GridIntensity.data = []
 GridIntensity.intensityProvider = settings.uk
+
+GridIntensity.fetchIntensityData = async function() {
+  debug("fetchIntensityData")
+  const urlString = this.buildFetchUrl()
+  try {
+    const res = await fetch(urlString)
+    this.data = await res.json()
+  } catch (error) {
+    console.error("Couldn't fetch new data. Doing nothing further")
+    console.error(error)
+  }
+  return this.data
+}
 
 export default GridIntensity


### PR DESCRIPTION
This is an experiment, in trying a different way to structure the code, as I read through this.

The idea to do away with the declaring GridIntensity as a kind of function/class hybrid - where I've been mapping my understanding of class based inheritance like you might see in other languages like Python, in favor of treating the code like what really is - plain javascript objects, which have Prototypes instead.

By doing this, I'm hoping it's clearer where the shared code used by both the node and browser libraries might live, versus the code that is specific the environment using it.

For example, in a browser when we are trying to make GridIntensity queries, we are explicit about using the browser's implementation of `localStorage`, and `fetch`  for making queries, but the rest of behaviour ought to be the same.

This means we should end up with less code to maintain.

This is largely kicked off by me getting a better understanding of what's happening under the hood with javascript's object system, as described in this page here:

https://github.com/getify/You-Dont-Know-JS/blob/1st-ed/this%20%26%20object%20prototypes/ch5.md#object-links

